### PR TITLE
chore: update port from 5000 to 5001 for server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: server
       dockerfile: Dockerfile
     ports:
-      - "5000:5000"
+      - "5001:5000"
 
   splunk:
     image: splunk/splunk:latest

--- a/globalConfig.json
+++ b/globalConfig.json
@@ -180,13 +180,13 @@
     "meta": {
         "name": "Splunk_TA_Example",
         "restRoot": "Splunk_TA_Example",
-        "version": "0.0.1+6c22cac",
+        "version": "0.0.1+dbfd8ed",
         "displayName": "Splunk Add-on for Example",
         "schemaVersion": "0.0.9",
         "supportedThemes": [
             "light",
             "dark"
         ],
-        "_uccVersion": "5.53.1"
+        "_uccVersion": "5.53.0"
     }
 }

--- a/globalConfig.json
+++ b/globalConfig.json
@@ -180,13 +180,13 @@
     "meta": {
         "name": "Splunk_TA_Example",
         "restRoot": "Splunk_TA_Example",
-        "version": "0.0.1+dbfd8ed",
+        "version": "0.0.1+6c22cac",
         "displayName": "Splunk Add-on for Example",
         "schemaVersion": "0.0.9",
         "supportedThemes": [
             "light",
             "dark"
         ],
-        "_uccVersion": "5.53.0"
+        "_uccVersion": "5.53.1"
     }
 }

--- a/package/bin/example_helper.py
+++ b/package/bin/example_helper.py
@@ -37,7 +37,7 @@ def get_data_from_api(
 
     def _call_api():
         response = requests.get(
-            "http://server:5000/events",
+            "http://server:5001/events",
             headers={
                 "API-Key": api_key,
             },


### PR DESCRIPTION
Updating port from 5000 to 5001 for `server` to unblock folks who run on a newer macOS version.