### PR TITLE
chore: adjust running scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ ucc-gen package --path output/Splunk_TA_Example
 ## Build and run Splunk and `server`
 
 ```bash
-cd scripts
-./run_locally.sh
+./scripts/run_locally.sh
 ```
 
 ## Notable PRs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,19 @@
+name: splunk-example-ta
 services:
   server:
+    container_name: server-example-ta
     build:
       context: server
       dockerfile: Dockerfile
-    ports:
-      - "5000:5000"
 
   splunk:
     image: splunk/splunk:latest
-    hostname: splunk
+    container_name: splunk-example-ta
     ports:
       - "8000:8000"
-      - "8088:8088"
-      - "8089:8089"
     environment:
-      - SPLUNK_PASSWORD=Chang3d!
-      - SPLUNK_HEC_TOKEN=4a8a737d-5452-426c-a6f7-106dca4e813f
-      - SPLUNK_START_ARGS=--accept-license
+      - SPLUNK_PASSWORD=${SPLUNK_PASSWORD:-Chang3d!}
+      - SPLUNK_HEC_TOKEN=${SPLUNK_HEC_TOKEN:-4a8a737d-5452-426c-a6f7-106dca4e813f}
+      - SPLUNK_START_ARGS=${SPLUNK_START_ARGS:---accept-license}
     volumes:
       - ./output/Splunk_TA_Example:/opt/splunk/etc/apps/Splunk_TA_Example

--- a/scripts/run_locally.sh
+++ b/scripts/run_locally.sh
@@ -1,4 +1,10 @@
-cd ../
+#!/bin/bash
+set -e
+
+# Determine the directory of the script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+cd "$SCRIPT_DIR"/..
 docker compose down
 python3 -m venv .venv
 source .venv/bin/activate
@@ -6,6 +12,5 @@ pip install -r requirements-dev.txt
 ucc-gen build
 # running on ARM macOS
 export DOCKER_DEFAULT_PLATFORM=linux/amd64
-docker compose up -d --build
-echo -n "Waiting Splunk for run"
-until curl -Lsk "https://localhost:8088/services/collector/health" &>/dev/null ; do echo -n "." && sleep 5 ; done
+docker compose up -d --build --wait
+

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,7 +1,5 @@
 FROM python:3.12-alpine
 
-EXPOSE 5000/tcp
-
 WORKDIR /app
 
 COPY requirements.txt .


### PR DESCRIPTION
- allow `run_locally.sh` to run from any folder
- utilize the internal docker healthchecks instead of curl pings
- specify container name instead of ephemeral names
- no ports are exposed except 8000