### PR TITLE
test: change the way of getting and creating indexes

### DIFF
--- a/tests/ucc_modinput_functional/splunk/forges.py
+++ b/tests/ucc_modinput_functional/splunk/forges.py
@@ -323,14 +323,8 @@ def another_account_index(
     splunk_client: SplunkClient,
 ) -> Generator[Dict[str, str], None, None]:
     index_name = f"idx_mit_another_account_{utils.Common().sufix}"
-    splk_conf = splunk_client.splunk_configuration
-    splk_conf.create_index(
+    splunk_client.create_index(
         index_name,
-        splk_conf.service,
-        is_cloud=splk_conf.is_cloud,
-        acs_stack=splk_conf._acs_stack,
-        acs_server=splk_conf.acs_server,
-        splunk_token=splk_conf.token,
     )
     yield {"another_account_index_name": index_name}
 

--- a/tests/ucc_modinput_functional/test_configuration.py
+++ b/tests/ucc_modinput_functional/test_configuration.py
@@ -73,9 +73,8 @@ def test_accounts(
     ),
 )
 def test_indexes(splunk_client: SplunkClient, another_account_index_name: str) -> None:
-    splk_config = splunk_client.splunk_configuration
-    actual_index = splk_config.get_index(
-        another_account_index_name, client_service=splk_config.service
+    actual_index = splunk_client.get_index(
+        another_account_index_name,
     )
     assert actual_index is not None
     assert actual_index.name == another_account_index_name


### PR DESCRIPTION
This PR changes the way of getting indexes, by using SplunkClientBase.get_index instead of Configuration.get_index.